### PR TITLE
Update entrypoint script to deal with fresh DB instances

### DIFF
--- a/diacamma/Dockerfile
+++ b/diacamma/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch
 RUN apt-get update && \
     apt-get install -y \
         curl \
-	default-libmysqlclient-dev \
+        default-libmysqlclient-dev \
         locales \
         locales-all && \
     rm -rf /var/lib/apt/lists/*

--- a/diacamma/entrypoint.sh
+++ b/diacamma/entrypoint.sh
@@ -8,6 +8,9 @@ diacamma_database=${DIACAMMA_DATABASE}
 echo Organisation: $organisation
 echo Type: $diacamma_type
 
+# Wait for DB to be ready before starting this
+[ "$diacamma_database" != "" ] && sleep 10
+
 if [ ! -f /var/lucterios2/$organisation/settings.py ]
 then
   case "$diacamma_type" in
@@ -22,19 +25,20 @@ then
       exit 1
       ;;
   esac
+
   database_parameter=""
   [ "$diacamma_database" != "" ] && database_parameter="-d $diacamma_database"
+
   /var/lucterios2/launch_lucterios.sh add -n $organisation -m "$modules" -p diacamma.$diacamma_type $database_parameter
 
-  cat <<EOF >> /var/lucterios2/$organisation/settings.py
-LANGUAGE_CODE = 'fr'
-ALLOWED_HOSTS = ["*"]
-EOF
-
+  echo "LANGUAGE_CODE = 'fr'" >> /var/lucterios2/$organisation/settings.py
+  echo "ALLOWED_HOSTS = [ '*' ]" >> /var/lucterios2/$organisation/settings.py
 fi
 
 cd /var/lucterios2
 source virtual_for_lucterios/bin/activate
 export DJANGO_SETTINGS_MODULE="${organisation}.settings"
-exec gunicorn lucterios.framework.wsgi --bind=0.0.0.0:8100 --access-logfile - --error-logfile -
 
+[ "$diacamma_database" != "" ] && /var/lucterios2/launch_lucterios.sh refreshall
+
+exec gunicorn lucterios.framework.wsgi --bind=0.0.0.0:8100 --access-logfile - --error-logfile -


### PR DESCRIPTION
This is for fixing new DB instance that are empty.
It calls the refreshall script in order to build the DB schema.