### PR TITLE
Enable version specification

### DIFF
--- a/diacamma/Dockerfile
+++ b/diacamma/Dockerfile
@@ -14,11 +14,15 @@ ENV LANG fr_FR.UTF-8
 ENV LANGUAGE fr_FR:fr
 ENV LC_ALL fr_FR.UTF-8
 
+ENV ASSO_VERSION_CONSTRAINT=""
+ENV SYNDIC_VERSION_CONSTRAINT=""
+ENV LUCTERIOS_VERSION_CONSTRAINT=""
+
 RUN curl --location -o /tmp/Diacamma_setup.tar.gz http://www.sd-libre.fr/download/Diacamma_setup.tar.gz
 RUN cd /tmp && tar zxvf /tmp/Diacamma_setup.tar.gz
 
 RUN apt-get update && \
-    /tmp/Diacamma/install.sh && \
+    /tmp/Diacamma/install.sh -p "diacamma-asso${ASSO_VERSION_CONSTRAINT} diacamma-syndic${SYNDIC_VERSION_CONSTRAINT} lucterios-standard${LUCTERIOS_VERSION_CONSTRAINT}" && \
     rm -rf /var/lib/apt/lists/*
 
 RUN cd /var/lucterios2 && \

--- a/diacamma/README.md
+++ b/diacamma/README.md
@@ -10,6 +10,22 @@ Here are environment possible values
 | DIACAMMA_ORGANISATION | any string (no space allowed) | N/A                  | name for your Diacamma instance                                 |
 | DIACAMMA_DATABASE     | Refer to Database Section     | SQLite used if empty | connection string to the database used by DIACAMMA |
 
+## Building with sticked version
+
+You can build an image with forced version of each component.
+| Component         | default constaint | package                                              |
+|:------------------|:------------------|:-----------------------------------------------------|
+|diacamma-asso      | empty (latest)    | https://pypi.org/project/diacamma-asso/#history      |
+|diacamma-syndic    | empty (latest)    | https://pypi.org/project/diacamma-syndic/#history    |
+|lucterios-standard | empty (latest)    | https://pypi.org/project/lucterios-standard/#history |
+
+Constraint have to be compatible with pip install syntax (refer to https://www.python.org/dev/peps/pep-0440/#version-specifiers for more infos)
+
+### Example
+```bash
+docker build -e ASSO_VERSION_CONSTRAINT="==2.3.0.18070322" -e SYNDIC_VERSION_CONSTRAINT="==2.3.0.18073020" LUCTERIOS_VERSION_CONSTRAINT="==2.3.0.18070322" .
+```
+
 ## Databases
 
 ### Use SQLite Database


### PR DESCRIPTION
I made a change on Docker file o enable the version sticking when building th image ion order to avoid kind of issue from diacamma.org, and also to provide more docker image based on their real version.